### PR TITLE
fix: type=button on the trigger button

### DIFF
--- a/src/components/multi-select.tsx
+++ b/src/components/multi-select.tsx
@@ -196,6 +196,7 @@ export const MultiSelect = React.forwardRef<
       >
         <PopoverTrigger asChild>
           <Button
+            type="button"
             ref={ref}
             {...props}
             onClick={handleTogglePopover}


### PR DESCRIPTION
I was just implementing this multiselect component and I found that, when the form has onSubmit handler and user click on the multiselect trigger, the form submits. So, I have just added the type="button" in the multiselect.tsx file, which will stop that from happening.

![image](https://github.com/user-attachments/assets/fd0f6433-adf5-48ba-a5e6-dab5833d756c)
