### PR TITLE
X icons are not clickable bug

### DIFF
--- a/README.md
+++ b/README.md
@@ -227,7 +227,7 @@ export const MultiSelect = React.forwardRef<
             {...props}
             onClick={handleTogglePopover}
             className={cn(
-              "flex w-full p-1 rounded-md border min-h-10 h-auto items-center justify-between bg-inherit hover:bg-inherit",
+              "flex w-full p-1 rounded-md border min-h-10 h-auto items-center justify-between bg-inherit hover:bg-inherit [&_svg]:pointer-events-auto",
               className
             )}
           >

--- a/src/components/multi-select.tsx
+++ b/src/components/multi-select.tsx
@@ -200,7 +200,7 @@ export const MultiSelect = React.forwardRef<
             {...props}
             onClick={handleTogglePopover}
             className={cn(
-              "flex w-full p-1 rounded-md border min-h-10 h-auto items-center justify-between bg-inherit hover:bg-inherit",
+              "flex w-full p-1 rounded-md border min-h-10 h-auto items-center justify-between bg-inherit hover:bg-inherit [&_svg]:pointer-events-auto",
               className
             )}
           >


### PR DESCRIPTION
I just found out this component and it's really cool, thanks a lot! One thing missing was "X" buttons wasn't working, I was really confused but after some research I found the solution.
https://ui.shadcn.com/docs/components/button
There's a changelog at the bottom of the page which says
"2024-10-16 Classes for icons
Added gap-2 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0 to the button to automatically style icon inside the button."
So yeah, "[&_svg]:pointer-events-none" this one is preventing from clicking to the "X" icons. So I added "[&_svg]:pointer-events-auto" to "Button" className, it's working same like in the demo website right now.