### PR TITLE
Fix: Scrolling Issue in Popover with Large Lists

### DIFF
--- a/README.md
+++ b/README.md
@@ -215,6 +215,14 @@ export const MultiSelect = React.forwardRef<
       }
     };
 
+    const stopWheelEventPropagation: React.WheelEventHandler = (e) => {
+      e.stopPropagation();
+    };
+
+    const stopTouchMoveEventPropagation: React.TouchEventHandler = (e) => {
+      e.stopPropagation();
+    };
+
     return (
       <Popover
         open={isPopoverOpen}
@@ -309,6 +317,8 @@ export const MultiSelect = React.forwardRef<
           className="w-auto p-0"
           align="start"
           onEscapeKeyDown={() => setIsPopoverOpen(false)}
+          onWheel={stopWheelEventPropagation}
+          onTouchMove={stopTouchMoveEventPropagation}
         >
           <Command>
             <CommandInput

--- a/src/components/multi-select.tsx
+++ b/src/components/multi-select.tsx
@@ -188,6 +188,10 @@ export const MultiSelect = React.forwardRef<
       }
     };
 
+    const stopWheelEventPropagation: React.WheelEventHandler = (e) => {
+      e.stopPropagation();
+    };
+
     return (
       <Popover
         open={isPopoverOpen}
@@ -282,6 +286,7 @@ export const MultiSelect = React.forwardRef<
           className="w-auto p-0"
           align="start"
           onEscapeKeyDown={() => setIsPopoverOpen(false)}
+          onWheel={stopWheelEventPropagation}
         >
           <Command>
             <CommandInput

--- a/src/components/multi-select.tsx
+++ b/src/components/multi-select.tsx
@@ -192,6 +192,10 @@ export const MultiSelect = React.forwardRef<
       e.stopPropagation();
     };
 
+    const stopTouchMoveEventPropagation: React.TouchEventHandler = (e) => {
+      e.stopPropagation();
+    };
+
     return (
       <Popover
         open={isPopoverOpen}
@@ -287,6 +291,7 @@ export const MultiSelect = React.forwardRef<
           align="start"
           onEscapeKeyDown={() => setIsPopoverOpen(false)}
           onWheel={stopWheelEventPropagation}
+          onTouchMove={stopTouchMoveEventPropagation}
         >
           <Command>
             <CommandInput


### PR DESCRIPTION
This PR resolves an issue where scrolling or touch gestures within the PopoverContent were not functioning correctly for large lists.
Stopping the wheel event propagation on the PopoverContent resolves the issue.


