### PR TITLE
Bug fixed: Close button on each badge was not removing the item.

### DIFF
--- a/src/components/multi-select.tsx
+++ b/src/components/multi-select.tsx
@@ -214,6 +214,7 @@ export const MultiSelect = React.forwardRef<
                       <Badge
                         key={value}
                         className={cn(
+                          "[&>svg]:pointer-events-auto",
                           isAnimating ? "animate-bounce" : "",
                           multiSelectVariants({ variant })
                         )}
@@ -236,6 +237,7 @@ export const MultiSelect = React.forwardRef<
                   {selectedValues.length > maxCount && (
                     <Badge
                       className={cn(
+                        "[&>svg]:pointer-events-auto",
                         "bg-transparent text-foreground border-foreground/1 hover:bg-transparent",
                         isAnimating ? "animate-bounce" : "",
                         multiSelectVariants({ variant })


### PR DESCRIPTION
## Issue
The issue arises from using the latest badge component from shadcn; which has a default behavior to set the pointer-events to none for SVG's.

## Implementation
Same was fixed by applying  to the badge in the multi-select component.

## Other Ways to solve the problem (not-recommended)
While there are other ways to solve the same problem, for example, changing the  in the badge component itself, but that would most probably break the components that you use from the shadcn itself. So it's wise to change that here.